### PR TITLE
Added support for WordPress networks and static defines

### DIFF
--- a/rapid-twitter-widget.php
+++ b/rapid-twitter-widget.php
@@ -305,26 +305,41 @@ class Rapid_Twitter_Controller {
 	}
 
 	function output_key_field() {
-		$this->output_text_field( 'key' );
+		if ( ! defined('RAPID_TWITTER_KEY') ) {
+    		$this->output_text_field( 'key' );
+		} else {
+    		echo RAPID_TWITTER_KEY . '<br /><em>Globally defined in wp-config.php.</em>';
+		}
+
 	}
 	
 	function output_secret_field(){
-		$this->output_text_field( 'secret' );
+	    if ( ! defined('RAPID_TWITTER_SECRET') ) {
+    	    $this->output_text_field( 'secret' );
+	    } else {
+    	    echo RAPID_TWITTER_SECRET . '<br /><em>Globally defined in wp-config.php.</em>';
+	    }
+		
 	}
 	
 	function output_text_field( $id ) {
 		$val = esc_attr( $this->options[$id] );
 		
 		echo '<input class="text" type="text" ';
-		echo 'id="rapid_twitter_widget_api_' . $id . '" ';
-		echo 'name="rapid_twitter_widget_api[' . $id . ']" ';
-		echo 'size="30" value="' . $val . '"/>';
+        echo 'id="rapid_twitter_widget_api_' . $id . '" ';
+        echo 'name="rapid_twitter_widget_api[' . $id . ']" ';
+        echo 'size="30" value="' . $val . '"/>';
 	}
 	
 	function get_options() {
 		$options = &$this->options;
 		
-		$options = get_option( 'rapid_twitter_widget_api' );
+		if ( ! defined( 'RAPID_TWITTER_KEY' ) && ! defined ( 'RAPID_TWITTER_SECRET' ) ) {
+    		$options = get_site_option( 'rapid_twitter_widget_api' );
+		} else {
+    		$options['key'] = RAPID_TWITTER_KEY;
+    		$options['secret'] = RAPID_TWITTER_SECRET;
+		}
 		
 		if ( $options['key'] AND $options['secret'] ) {
 			// get the token
@@ -352,11 +367,11 @@ class Rapid_Twitter_Controller {
 		
 		$signature = base64_encode( $key_encode . ':' . $secret_encode );
 		
-		$token = get_transient( 'rapid_twitter_widget_token' );
+		$token = get_site_transient( 'rapid_twitter_widget_token' );
 		
 		if ( $token AND ( $token['signature'] != $signature ) ) {
 			unset( $token );
-			delete_transient( 'rapid_twitter_widget_token' );
+			delete_site_transient( 'rapid_twitter_widget_token' );
 		}
 		
 		if ( !$token ) {
@@ -379,7 +394,7 @@ class Rapid_Twitter_Controller {
 				$token = json_decode( $response_body, true );
 				$token['signature'] = $signature;
 				
-				set_transient('rapid_twitter_widget_token', $token, 60*60*12 );
+				set_site_transient('rapid_twitter_widget_token', $token, 60*60*12 );
 				
 			}
 		}
@@ -405,7 +420,7 @@ class Rapid_Twitter_Controller {
 		
 		if ( $access_token ) {
 			//the key & secret are valid
-			update_option( 'rapid_twitter_widget_api', $options );
+			update_site_option( 'rapid_twitter_widget_api', $options );
 			echo '<div class="updated"><p>Twitter application updated.</p></div>';
 			
 			//return the access token to the options array
@@ -495,7 +510,7 @@ class Rapid_Twitter_Controller {
 		$transient_backup = substr( $transient_backup, 0, 45 );
 		
 		
-		$tweets = get_transient( $transient_name );
+		$tweets = get_site_transient( $transient_name );
 		
 		if ( !$tweets ) {
 			$response = wp_remote_get( $http_url, $http_args );


### PR DESCRIPTION
This modifies the get_option/set_option and get_transient/set_transient for config data (i.e. key, secret and token) with get_site_option/set_site_option and get_site_transient/set_site_transient. However, each site maintains it's own transient for the actual tweets in that site.

It also allows admins to define('RAPID_TWITTER_KEY') and define('RAPID_TWITTER_SECRET') in wp-config.php which will globally disable the configuration fields in WordPress Administration.